### PR TITLE
feat: Add Telegram support for daily news PDF

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,10 @@ CROSSWORD_SENDER_EMAIL_ADDRESS_DOMAIN=gmail.com
 CROSSWORD_SENDER_EMAIL_APP_PASSWORD='super secret password here'
 # The email address that receives your PDFs and delivers to your kindle
 KINDLE_EMAIL_ADDRESS="myawesomekindleemail@kindle.com"
+# Optional: Telegram bot details for sending daily summaries. If these are set, the summary will be sent to the specified chat ID.
+# Leave blank to disable Telegram sending.
+TELEGRAM_BOT_TOKEN="your_telegram_bot_token_here"
+TELEGRAM_CHAT_ID="your_chat_id_here"
 
 ####################################################################
 # OPTIONAL (you do not need to change these if you don't want to): #

--- a/download-cbc-news.sh
+++ b/download-cbc-news.sh
@@ -113,20 +113,16 @@ function send_to_telegram() {
         return
     fi
 
-    if [ -z "${DISABLE_SEND}" ]; then
-        echo "Sending file ${pdf_name} to Telegram chat ${TELEGRAM_CHAT_ID}"
-        response=$(curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendDocument" \
-            -F chat_id="${TELEGRAM_CHAT_ID}" \
-            -F document=@"${pdf_path}" \
-            -F caption="Here is your daily news summary 📰")
-        
-        if echo "${response}" | grep -q '"ok":true'; then
-            echo "Telegram send successful!"
-        else
-            echo "Telegram send failed: ${response}"
-        fi
+    echo "Sending file ${pdf_name} to Telegram chat ${TELEGRAM_CHAT_ID}"
+    response=$(curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendDocument" \
+        -F chat_id="${TELEGRAM_CHAT_ID}" \
+        -F document=@"${pdf_path}" \
+        -F caption="Here is your daily news summary 📰")
+    
+    if echo "${response}" | grep -q '"ok":true'; then
+        echo "Telegram send successful!"
     else
-        echo "Sending detected as disabled. Will not send file ${pdf_name} to Telegram."
+        echo "Telegram send failed: ${response}"
     fi
 }
 

--- a/download-cbc-news.sh
+++ b/download-cbc-news.sh
@@ -22,8 +22,8 @@ function verify_env_vars() {
         exit 1
     fi
 
-    if [ -z "${KINDLE_EMAIL_ADDRESS}" ]; then
-        echo "Kindle email address not set in environment variable KINDLE_EMAIL_ADDRESS. Exiting."
+    if [ -z "${KINDLE_EMAIL_ADDRESS}" ] && { [ -z "${TELEGRAM_BOT_TOKEN}" ] || [ -z "${TELEGRAM_CHAT_ID}" ]; }; then
+        echo "Neither Kindle email address nor Telegram details are set. Nothing to do. Exiting."
         exit 1
     fi
 
@@ -89,6 +89,11 @@ function fetch_and_process_rss() {
 function send_to_kindle() {
     local pdf_path="${1}"
     local pdf_name=$(basename "${pdf_path}")
+
+    if [ -z "${KINDLE_EMAIL_ADDRESS}" ]; then
+        echo "Kindle email not set. Skipping Kindle send."
+        return
+    fi
 
     if [ -z "${DISABLE_SEND}" ]; then
         echo "Sending file ${pdf_name} to kindle email address ${KINDLE_EMAIL_ADDRESS}"

--- a/download-cbc-news.sh
+++ b/download-cbc-news.sh
@@ -99,6 +99,32 @@ function send_to_kindle() {
     fi
 }
 
+function send_to_telegram() {
+    local pdf_path="${1}"
+    local pdf_name=$(basename "${pdf_path}")
+
+    if [ -z "${TELEGRAM_BOT_TOKEN}" ] || [ -z "${TELEGRAM_CHAT_ID}" ]; then
+        echo "Telegram details not set. Skipping Telegram send."
+        return
+    fi
+
+    if [ -z "${DISABLE_SEND}" ]; then
+        echo "Sending file ${pdf_name} to Telegram chat ${TELEGRAM_CHAT_ID}"
+        response=$(curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendDocument" \
+            -F chat_id="${TELEGRAM_CHAT_ID}" \
+            -F document=@"${pdf_path}" \
+            -F caption="Here is your daily news summary 📰")
+        
+        if echo "${response}" | grep -q '"ok":true'; then
+            echo "Telegram send successful!"
+        else
+            echo "Telegram send failed: ${response}"
+        fi
+    else
+        echo "Sending detected as disabled. Will not send file ${pdf_name} to Telegram."
+    fi
+}
+
 function parse_flags() {
     while [ $# -gt 0 ]; do
         case $1 in
@@ -119,6 +145,7 @@ verify_env_vars
 parse_flags "$@"
 fetch_and_process_rss
 send_to_kindle "${OUTPUT_PDF_PATH}"
+send_to_telegram "${OUTPUT_PDF_PATH}"
 
 echo -e "-----------------CBC NEWS SENDER FINISHED-----------------
 "


### PR DESCRIPTION
This PR adds support for sending the daily CBC News summary PDF to a Telegram chat. Configure TELEGRAM_BOT_TOKEN and TELEGRAM_CHAT_ID in .env to enable.