### PR TITLE
Feature/home status rewrite

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,65 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Common commands
+
+Everything runs in a single Docker container; there is no native dev workflow.
+
+- Build & run (rebuilds image, recreates container): `docker compose up -d --build --force-recreate`
+- Tail logs: `docker compose logs -f`
+- Stop: `docker compose down`
+- One-off run with current code (skips the daily loop, useful for iterating): edit `.env` to add `--disable-send` to `CROSSWORD_COMMAND_LINE_ARGUMENTS`, then `docker compose up --build` and inspect output PDFs in `./downloads/`.
+- Re-run today's job without rebuilding: `docker exec crossword-sender ./download-crossword.sh $CROSSWORD_COMMAND_LINE_ARGUMENTS` (or `./download-cbc-news.sh`). The `.env` is bind-mounted, so edits take effect without rebuilding — but `main.sh` only re-sources it at the next daily tick.
+
+There is no test suite or linter. CI (`.github/workflows/ci.yaml`) only validates that PR titles follow Conventional Commits and previews the next semver tag — commits/PRs must be Conventional Commits style.
+
+## Architecture
+
+This is a Dockerized cron-loop that produces two PDFs each morning (NYT crossword + CBC news/HA briefing) and ships them to a Kindle (via SMTP) and/or Telegram.
+
+### Runtime shape
+
+`main.sh` is the entrypoint and the only long-running process. It runs the two download scripts once at startup, then loops forever: sleep until `CROSSWORD_DAILY_SEND_TIME` (in `TZ`), `source .env` to pick up edits, run both scripts again. The container has `restart: unless-stopped` but the loop itself does the scheduling — there is no system cron.
+
+### Two pipelines, sharing the same container
+
+1. **Crossword pipeline** (`download-crossword.sh`):
+   - Refreshes NYT session cookies in place against `https://a.nytimes.com/svc/nyt/data-layer` (writes back to `cookies.nyt.txt`).
+   - For `--version newspaper`: fetches a single PDF from `/svc/crosswords/v2/puzzle/print/<MMMddyy>.pdf`.
+   - For `games`/`big`/`southpaw`: looks up the `puzzle_id` from `/svc/crosswords/v3/puzzles.json`, downloads puzzle + answer PDFs, merges them with Ghostscript.
+   - On a date range, each day's PDF path is appended to a manifest file and Ghostscript merges them all at the end (unless `--multiple-pdfs`).
+   - `exiftool` rewrites author metadata to "The New York Times" before sending.
+
+2. **News pipeline** (`download-cbc-news.sh`):
+   - Calls `process_ha.py` → returns an HTML snippet containing a Gemini-generated Home Assistant briefing plus an inline SVG temperature chart built from HA history. Skipped gracefully if `HA_TOKEN`/`GEMINI_API_KEY` aren't set.
+   - Calls `process_rss.py` with that snippet + the CBC RSS URL list → returns a full HTML document.
+   - Calls `process_html.py` to strip `<img>` tags (Kindle/weasyprint friendliness).
+   - `weasyprint` renders the final HTML to PDF.
+   - `CBC_RSS_FEEDS` (comma-separated) overrides the default URL list; `CBC_OUTPUT_PATH` overrides the output dir.
+
+### Delivery
+
+Both pipelines reuse the same delivery helpers:
+- **Kindle**: `mutt` with the config in `Muttrc`, which is templated from `CROSSWORD_SENDER_EMAIL_*` env vars at container startup. Skipped if `KINDLE_EMAIL_ADDRESS` is unset.
+- **Telegram** (news only): `curl` POST to `sendDocument`. Skipped if `TELEGRAM_BOT_TOKEN`/`TELEGRAM_CHAT_ID` are unset. Note: the news script ignores `--disable-send` for Telegram (per recent commits — Telegram always fires).
+- The crossword script requires `KINDLE_EMAIL_ADDRESS`; the news script requires *either* Kindle *or* Telegram credentials.
+
+### Container layout
+
+- Base: Alpine + a Python venv at `/opt/venv` (weasyprint, bs4, lxml, feedparser, google-genai, python-dotenv, google-* auth libs).
+- WORKDIR: `/crosswords`. Scripts live there; `tmp/` is used for intermediate HTML files.
+- Volumes (from `docker-compose.yml`):
+  - `${CROSSWORD_DOWNLOADS_PATH} → /crosswords/downloads` (output PDFs)
+  - `${NYT_COOKIES_PATH} → /crosswords/cookies.nyt.txt` (mutated in place by the cookie refresh)
+  - `./.env → /crosswords/.env` (so edits land in the container without rebuilding)
+  - `./process_ha.py → /crosswords/process_ha.py` (live-edit the HA logic without rebuilding)
+- `network_mode: host` so the container can reach a LAN Home Assistant URL.
+- Runs as the unprivileged `crossword` user.
+
+### Things that aren't obvious
+
+- `setup_gmail_auth.py` is a standalone helper for generating a Gmail OAuth `token.json` — it isn't wired into the runtime container and isn't `COPY`'d in the Dockerfile. It's leftover/optional tooling.
+- `StoneCrownOfCashel/` is unrelated static content (audio/PDF/midi). Don't touch unless asked.
+- `cookies.nyt.txt` is rewritten on every run — a pulled fresh cookies file from your browser is the right move when auth breaks, not a code fix.
+- The `--disable-send` flag prevents the crossword email send and the *Kindle* news send, but **not** the Telegram news send.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,11 +8,11 @@ services:
       context: .
     env_file:
       - .env
+    network_mode: host
+    restart: unless-stopped
     volumes:
       - ${CROSSWORD_DOWNLOADS_PATH}:/crosswords/downloads
       - ${NYT_COOKIES_PATH}:/crosswords/cookies.nyt.txt
       # To allow for changing .env without restarting the container
       - ./.env:/crosswords/.env
-      - ./token.json:/crosswords/token.json
-      - ./settings.json:/crosswords/settings.json
       - ./process_ha.py:/crosswords/process_ha.py

--- a/process_ha.py
+++ b/process_ha.py
@@ -1,249 +1,486 @@
-#! /usr/bin/env python3
+#!/usr/bin/env python3
+"""Render the Home Status section of the morning briefing PDF.
 
-import os
+Emits a single <div id="ha-daily-update"> ... </div> on stdout, suitable for
+inclusion at the top of the CBC News HTML before weasyprint converts to PDF.
+
+Fully deterministic — pulls live state from Home Assistant REST and renders
+sections individually. A failing section logs to stderr and renders empty;
+the rest of the briefing still shows.
+"""
+
 import json
+import os
+import sys
+import urllib.error
 import urllib.request
-import datetime
-from datetime import date
-from google import genai
+from datetime import datetime, timedelta
+from urllib.parse import urlencode
+from zoneinfo import ZoneInfo
+
 from dotenv import load_dotenv
 
-def get_ha_state(base_url, token):
-    """
-    Fetches all states from Home Assistant API.
-    """
-    url = f"{base_url}/api/states"
-    headers = {
-        "Authorization": f"Bearer {token}",
-        "Content-Type": "application/json",
-    }
-    
-    try:
-        req = urllib.request.Request(url, headers=headers)
-        with urllib.request.urlopen(req) as response:
-            data = json.loads(response.read().decode('utf-8'))
-            return data
-    except Exception as e:
-        print(f"Error fetching HA state: {e}", flush=True)
-        return []
+WRAPPER_STYLE = (
+    'font-family: sans-serif; padding: 10px; '
+    'border: 1px solid #ccc; border-radius: 5px;'
+)
+LOW_BATTERY_THRESHOLD = 20
+FORECAST_HOURS = 12
+WEATHER_ENTITY = 'weather.forecast_home'
+WASTE_CALENDAR = 'calendar.halifax_ns'
+SHOPPING_LIST = 'todo.shopping_list'
 
-def get_history(base_url, token, entity_ids, hours=24):
-    """
-    Fetches history for specific entities.
-    """
-    start_time = (datetime.datetime.now() - datetime.timedelta(hours=hours)).isoformat()
-    ids_str = ",".join(entity_ids)
-    # minimal_response=true reduces payload size (no attributes)
-    url = f"{base_url}/api/history/period/{start_time}?filter_entity_id={ids_str}&minimal_response=true"
-    
-    headers = {
-        "Authorization": f"Bearer {token}",
-        "Content-Type": "application/json",
-    }
-    
-    try:
-        req = urllib.request.Request(url, headers=headers)
-        with urllib.request.urlopen(req) as response:
-            return json.loads(response.read().decode('utf-8'))
-    except Exception as e:
-        print(f"Error fetching history: {e}", flush=True)
-        return []
 
-def create_line_chart(histories):
-    """
-    Generates a simple SVG line chart from HA history data.
-    """
-    if not histories:
-        return ""
-        
-    width = 600
-    height = 150
-    padding = 20
-    
-    parsed_series = []
-    all_temps = []
-    all_times = []
-    
-    for series in histories:
-        if not series: continue
-        points = []
-        name = series[0].get('entity_id')
-        
-        for point in series:
-            try:
-                val = float(point['state'])
-                # Handle Zulu time or standard ISO
-                ts_str = point['last_changed'].replace('Z', '+00:00')
-                dt = datetime.datetime.fromisoformat(ts_str)
-                ts = dt.timestamp()
-                
-                points.append((ts, val))
-                all_temps.append(val)
-                all_times.append(ts)
-            except (ValueError, TypeError):
-                continue
-        
-        if points:
-            parsed_series.append({'name': name, 'points': points})
-
-    if not parsed_series:
-        return ""
-
-    min_t, max_t = min(all_times), max(all_times)
-    min_y, max_y = min(all_temps), max(all_temps)
-    
-    # Add buffer
-    min_y -= 1
-    max_y += 1
-    if max_t == min_t: max_t += 1
-    if max_y == min_y: max_y += 1
-    
-    def scale_x(t):
-        return padding + (t - min_t) / (max_t - min_t) * (width - 2 * padding)
-    
-    def scale_y(y):
-        return height - padding - (y - min_y) / (max_y - min_y) * (height - 2 * padding)
-
-    svg_lines = []
-    colors = ["black", "#666666"] # High contrast for Kindle
-    
-    for i, s in enumerate(parsed_series):
-        pts_str = ""
-        for t, y in s['points']:
-            sx = scale_x(t)
-            sy = scale_y(y)
-            pts_str += f"{sx:.1f},{sy:.1f} "
-        
-        color = colors[i % len(colors)]
-        # Dashed line for secondary series
-        dash = 'stroke-dasharray="5,5"' if i > 0 else ""
-        svg_lines.append(f'<polyline points="{pts_str.strip()}" fill="none" stroke="{color}" stroke-width="2" {dash} />')
-
-    svg = f"""
-    <div style="margin-top: 15px;">
-        <h3>Termperature (24h)</h3>
-        <svg width="100%" viewBox="0 0 {width} {height}" xmlns="http://www.w3.org/2000/svg" style="border: 1px solid #eee;">
-            <!-- Grid -->
-            <line x1="{padding}" y1="{padding}" x2="{padding}" y2="{height-padding}" stroke="#ddd" stroke-width="1"/>
-            <line x1="{padding}" y1="{height-padding}" x2="{width-padding}" y2="{height-padding}" stroke="#ddd" stroke-width="1"/>
-            
-            <!-- Labels -->
-            <text x="{padding+5}" y="{padding+10}" font-family="sans-serif" font-size="12" fill="black">{max_y:.0f}°</text>
-            <text x="{padding+5}" y="{height-padding-5}" font-family="sans-serif" font-size="12" fill="black">{min_y:.0f}°</text>
-            <text x="{width/2}" y="{height-5}" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#666">Time &rarr;</text>
-            
-            {''.join(svg_lines)}
-        </svg>
-        <p style="font-size: 10px; color: #666;">Solid: Living Room | Dashed: Office</p>
-    </div>
-    """
-    
-    return svg
-
-def filter_states(states):
-    """
-    Filters the massive state list down to interesting entities.
-    """
-    interesting_domains = [
-        "sensor", "binary_sensor", "climate", "switch", "light", "lock", "cover", "calendar", "weather"
-    ]
-    
-    filtered = []
-    for entity in states:
-        entity_id = entity.get("entity_id", "")
-        domain = entity_id.split(".")[0]
-        
-        if domain not in interesting_domains:
-            continue
-            
-        state = entity.get("state")
-        if state in ["unavailable", "unknown"]:
-            continue
-
-        attributes = entity.get("attributes", {})
-        friendly_name = attributes.get("friendly_name", entity_id)
-        
-        item = {
-            "name": friendly_name,
-            "entity_id": entity_id,
-            "state": state,
-            "unit": attributes.get("unit_of_measurement", ""),
-            "class": attributes.get("device_class", "")
+class HA:
+    def __init__(self, base_url, token):
+        self.base = base_url.rstrip('/')
+        self.headers = {
+            'Authorization': f'Bearer {token}',
+            'Content-Type': 'application/json',
         }
-        filtered.append(item)
-        
-    return filtered
+        self._states = None
+
+    def _request(self, method, path, body=None, query=None):
+        url = f'{self.base}{path}'
+        if query:
+            url += '?' + urlencode(query)
+        data = json.dumps(body).encode('utf-8') if body is not None else None
+        req = urllib.request.Request(url, data=data, method=method, headers=self.headers)
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return json.loads(resp.read().decode('utf-8'))
+
+    def states(self):
+        if self._states is None:
+            self._states = self._request('GET', '/api/states')
+        return self._states
+
+    def state(self, entity_id):
+        return next(
+            (s for s in self.states() if s.get('entity_id') == entity_id),
+            None,
+        )
+
+    def calendar_events(self, entity_id, start, end):
+        return self._request(
+            'GET',
+            f'/api/calendars/{entity_id}',
+            query={'start': start.isoformat(), 'end': end.isoformat()},
+        )
+
+    def forecast(self, entity_id, ftype='hourly'):
+        result = self._request(
+            'POST',
+            '/api/services/weather/get_forecasts',
+            body={'entity_id': entity_id, 'type': ftype},
+            query={'return_response': 'true'},
+        )
+        return (
+            result.get('service_response', {})
+            .get(entity_id, {})
+            .get('forecast', [])
+        )
+
+    def todo_items(self, entity_id, status='needs_action'):
+        result = self._request(
+            'POST',
+            '/api/services/todo/get_items',
+            body={'entity_id': entity_id, 'status': status},
+            query={'return_response': 'true'},
+        )
+        return (
+            result.get('service_response', {})
+            .get(entity_id, {})
+            .get('items', [])
+        )
+
+
+def section(label):
+    """Wrap a section renderer so a failure logs and returns ''."""
+    def wrap(fn):
+        def inner(*args, **kwargs):
+            try:
+                return fn(*args, **kwargs)
+            except Exception as e:
+                print(f'[ha-section:{label}] {type(e).__name__}: {e}', file=sys.stderr)
+                return ''
+        return inner
+    return wrap
+
+
+def parse_iso(value):
+    return datetime.fromisoformat(value.replace('Z', '+00:00'))
+
+
+def parse_event_time(event_side, tz):
+    """HA REST returns event start/end as either an ISO string or a {date|dateTime}
+    dict (varies by integration). Normalise to (datetime, is_all_day)."""
+    if isinstance(event_side, dict):
+        if 'dateTime' in event_side:
+            return parse_iso(event_side['dateTime']).astimezone(tz), False
+        if 'date' in event_side:
+            return datetime.fromisoformat(event_side['date']).replace(tzinfo=tz), True
+    elif isinstance(event_side, str):
+        if len(event_side) == 10:
+            return datetime.fromisoformat(event_side).replace(tzinfo=tz), True
+        return parse_iso(event_side).astimezone(tz), False
+    return None, False
+
+
+def fmt_clock(dt):
+    return dt.strftime('%-I:%M%p').lower().lstrip('0')
+
+
+def fmt_num(value, suffix=''):
+    if value is None:
+        return '—'
+    try:
+        return f'{float(value):g}{suffix}'
+    except (TypeError, ValueError):
+        return f'{value}{suffix}'
+
+
+@section('header')
+def render_header(ha, tz):
+    today = datetime.now(tz).strftime('%A, %B %-d, %Y')
+    sun = ha.state('sun.sun') or {}
+    attrs = sun.get('attributes', {})
+    parts = [f'<strong>Home Status</strong> &middot; {today}']
+    if attrs.get('next_setting'):
+        set_dt = parse_iso(attrs['next_setting']).astimezone(tz)
+        parts.append(f'Sunset {fmt_clock(set_dt)}')
+    if attrs.get('next_rising'):
+        rise_dt = parse_iso(attrs['next_rising']).astimezone(tz)
+        label = 'Sunrise' if rise_dt.date() == datetime.now(tz).date() else "Tomorrow's sunrise"
+        parts.append(f'{label} {fmt_clock(rise_dt)}')
+    return f'<p style="margin: 0 0 10px 0;">{" &middot; ".join(parts)}</p>'
+
+
+@section('weather_now')
+def render_weather_now(ha, tz):
+    w = ha.state(WEATHER_ENTITY)
+    if not w:
+        return ''
+    attrs = w.get('attributes', {})
+    condition = w.get('state', '').replace('_', ' ').replace('-', ' ').title()
+    temp_unit = attrs.get('temperature_unit', '°C')
+    bits = [f'<strong>{condition}</strong>']
+
+    high = low = None
+    try:
+        daily = ha.forecast(WEATHER_ENTITY, ftype='daily')
+        if daily:
+            high = daily[0].get('temperature')
+            low = daily[0].get('templow')
+    except Exception as e:
+        print(f'[ha-section:weather_now:daily] {type(e).__name__}: {e}', file=sys.stderr)
+
+    if attrs.get('temperature') is not None:
+        bits.append(f'now {fmt_num(attrs["temperature"], temp_unit)}')
+    if high is not None and low is not None:
+        bits.append(f'high {fmt_num(high, temp_unit)} / low {fmt_num(low, temp_unit)}')
+    if attrs.get('humidity') is not None:
+        bits.append(f'humidity {fmt_num(attrs["humidity"], "%")}')
+    if attrs.get('wind_speed') is not None:
+        bits.append(f'wind {fmt_num(attrs["wind_speed"], " " + attrs.get("wind_speed_unit", "km/h"))}')
+
+    return f'<p style="margin: 0 0 10px 0;">{", ".join(bits)}</p>'
+
+
+@section('hourly_forecast')
+def render_hourly_forecast(ha, tz):
+    forecast = ha.forecast(WEATHER_ENTITY, ftype='hourly')
+    if not forecast:
+        return ''
+    points = []
+    for entry in forecast[:FORECAST_HOURS]:
+        try:
+            dt = parse_iso(entry['datetime']).astimezone(tz)
+            temp = float(entry['temperature'])
+            precip = float(entry.get('precipitation_probability') or 0)
+            points.append((dt, temp, precip))
+        except (KeyError, TypeError, ValueError):
+            continue
+    if not points:
+        return ''
+
+    width, height = 600, 140
+    pad_l, pad_r, pad_t, pad_b = 30, 10, 15, 30
+    n = len(points)
+    temps = [p[1] for p in points]
+    precips = [p[2] for p in points]
+    times = [p[0] for p in points]
+
+    t_min, t_max = min(temps), max(temps)
+    if t_max == t_min:
+        t_max = t_min + 1
+
+    def x_of(i):
+        if n == 1:
+            return pad_l + (width - pad_l - pad_r) / 2
+        return pad_l + i * (width - pad_l - pad_r) / (n - 1)
+
+    def y_of_temp(t):
+        return pad_t + (t_max - t) / (t_max - t_min) * (height - pad_t - pad_b)
+
+    bar_w = max(4, (width - pad_l - pad_r) / n - 4)
+    bars = []
+    for i, p in enumerate(precips):
+        if p <= 0:
+            continue
+        bx = x_of(i) - bar_w / 2
+        bh = (height - pad_t - pad_b) * (p / 100.0) * 0.4
+        by = height - pad_b - bh
+        bars.append(
+            f'<rect x="{bx:.1f}" y="{by:.1f}" width="{bar_w:.1f}" '
+            f'height="{bh:.1f}" fill="#bbb" />'
+        )
+
+    poly = ' '.join(f'{x_of(i):.1f},{y_of_temp(t):.1f}' for i, t in enumerate(temps))
+
+    label_step = max(1, n // 4)
+    x_labels = []
+    for i in range(0, n, label_step):
+        lbl = times[i].strftime('%-I%p').lower().replace('m', '')
+        x_labels.append(
+            f'<text x="{x_of(i):.1f}" y="{height - 8}" text-anchor="middle" '
+            f'font-family="sans-serif" font-size="10" fill="#666">{lbl}</text>'
+        )
+
+    return f'''
+    <div style="margin: 0 0 10px 0;">
+        <svg width="100%" viewBox="0 0 {width} {height}" xmlns="http://www.w3.org/2000/svg">
+            <line x1="{pad_l}" y1="{height - pad_b}" x2="{width - pad_r}" y2="{height - pad_b}" stroke="#ddd" stroke-width="1"/>
+            {''.join(bars)}
+            <polyline points="{poly}" fill="none" stroke="black" stroke-width="2" />
+            <text x="{pad_l - 4}" y="{y_of_temp(t_max) + 4:.1f}" text-anchor="end" font-family="sans-serif" font-size="10" fill="black">{t_max:.0f}°</text>
+            <text x="{pad_l - 4}" y="{y_of_temp(t_min) + 4:.1f}" text-anchor="end" font-family="sans-serif" font-size="10" fill="black">{t_min:.0f}°</text>
+            {''.join(x_labels)}
+        </svg>
+        <p style="font-size: 10px; color: #666; margin: 0;">Next {FORECAST_HOURS}h: temperature line, precipitation chance bars.</p>
+    </div>
+    '''
+
+
+@section('anomalies')
+def render_anomalies(ha):
+    states = ha.states()
+    bullets = []
+
+    for s in states:
+        eid = s.get('entity_id', '')
+        if eid.startswith('binary_sensor.') and 'leak' in eid and s.get('state') == 'on':
+            name = s.get('attributes', {}).get('friendly_name', eid)
+            bullets.append(f'<li><strong>WATER LEAK:</strong> {name}</li>')
+
+    open_devices = []
+    for s in states:
+        if not s.get('entity_id', '').startswith('binary_sensor.'):
+            continue
+        attrs = s.get('attributes', {})
+        if attrs.get('device_class') in ('door', 'window', 'opening', 'garage_door') and s.get('state') == 'on':
+            open_devices.append(attrs.get('friendly_name', s['entity_id']))
+    if open_devices:
+        bullets.append(f'<li>Open: {", ".join(open_devices)}</li>')
+
+    low = []
+    for s in states:
+        eid = s.get('entity_id', '')
+        if not (eid.startswith('sensor.') and eid.endswith('_battery')):
+            continue
+        try:
+            level = float(s['state'])
+        except (KeyError, TypeError, ValueError):
+            continue
+        if level <= LOW_BATTERY_THRESHOLD:
+            name = s.get('attributes', {}).get('friendly_name', eid).removesuffix(' Battery')
+            low.append((level, name))
+    if low:
+        low.sort()
+        rendered = ', '.join(f'{n} ({l:.0f}%)' for l, n in low[:6])
+        bullets.append(f'<li>Low battery: {rendered}</li>')
+
+    unlocked = [
+        s.get('attributes', {}).get('friendly_name', s['entity_id'])
+        for s in states
+        if s.get('entity_id', '').startswith('lock.') and s.get('state') == 'unlocked'
+    ]
+    if unlocked:
+        bullets.append(f'<li>Unlocked: {", ".join(unlocked)}</li>')
+
+    if not bullets:
+        return ''
+
+    return (
+        '<div style="margin: 0 0 10px 0;">'
+        '<h3 style="margin: 0 0 4px 0;">Heads up</h3>'
+        f'<ul style="margin: 0; padding-left: 20px;">{"".join(bullets)}</ul>'
+        '</div>'
+    )
+
+
+@section('today_calendar')
+def render_today_calendar(ha, tz):
+    now = datetime.now(tz)
+    today_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
+    tomorrow = today_start + timedelta(days=1)
+    waste_window_end = today_start + timedelta(days=2)
+
+    rows = []
+
+    try:
+        waste_events = ha.calendar_events(WASTE_CALENDAR, today_start, waste_window_end)
+        by_date = {}
+        for e in waste_events:
+            start_dt, _ = parse_event_time(e.get('start'), tz)
+            if start_dt is None:
+                continue
+            by_date.setdefault(start_dt.date(), []).append(e.get('summary', '?'))
+        if by_date:
+            soonest = min(by_date)
+            if soonest == today_start.date():
+                label = 'Today'
+            elif soonest == tomorrow.date():
+                label = 'Tomorrow'
+            else:
+                label = soonest.strftime('%a %b %-d')
+            rows.append(
+                f'<li><strong>Waste {label}:</strong> {", ".join(by_date[soonest])}</li>'
+            )
+    except Exception as e:
+        print(f'[ha-section:today_calendar:waste] {type(e).__name__}: {e}', file=sys.stderr)
+
+    appointment_calendars = [
+        s['entity_id']
+        for s in ha.states()
+        if s.get('entity_id', '').startswith('calendar.')
+        and s['entity_id'] != WASTE_CALENDAR
+    ]
+
+    today_events = []
+    for cal in appointment_calendars:
+        try:
+            events = ha.calendar_events(cal, today_start, tomorrow)
+        except Exception as e:
+            print(f'[ha-section:today_calendar:{cal}] {type(e).__name__}: {e}', file=sys.stderr)
+            continue
+        for ev in events:
+            start_dt, all_day = parse_event_time(ev.get('start'), tz)
+            if start_dt is None:
+                continue
+            summary = ev.get('summary', '')
+            if all_day:
+                today_events.append((today_start, f'All day: {summary}'))
+            else:
+                today_events.append((start_dt, f'{fmt_clock(start_dt)} {summary}'))
+
+    today_events.sort(key=lambda x: x[0])
+    seen = set()
+    for _, label in today_events:
+        if label in seen:
+            continue
+        seen.add(label)
+        rows.append(f'<li>{label}</li>')
+
+    if not rows:
+        return ''
+
+    return (
+        '<div style="margin: 0 0 10px 0;">'
+        '<h3 style="margin: 0 0 4px 0;">Today</h3>'
+        f'<ul style="margin: 0; padding-left: 20px;">{"".join(rows)}</ul>'
+        '</div>'
+    )
+
+
+@section('climate')
+def render_climate_table(ha):
+    rows = []
+    for s in ha.states():
+        if not s.get('entity_id', '').startswith('climate.'):
+            continue
+        attrs = s.get('attributes', {})
+        name = attrs.get('friendly_name', s['entity_id'])
+        cur = attrs.get('current_temperature')
+        hum = attrs.get('current_humidity')
+        target = attrs.get('temperature')
+        action = attrs.get('hvac_action') or s.get('state', '—')
+        rows.append(
+            '<tr>'
+            f'<td>{name}</td>'
+            f'<td>{fmt_num(cur, "°")}</td>'
+            f'<td>{fmt_num(hum, "%")}</td>'
+            f'<td>{fmt_num(target, "°")}</td>'
+            f'<td>{action}</td>'
+            '</tr>'
+        )
+
+    if not rows:
+        return ''
+
+    return (
+        '<div style="margin: 0 0 10px 0;">'
+        '<h3 style="margin: 0 0 4px 0;">Indoor climate</h3>'
+        '<table style="border-collapse: collapse; width: 100%; font-size: 13px;">'
+        '<thead><tr style="text-align: left; border-bottom: 1px solid #ccc;">'
+        '<th>Room</th><th>Temp</th><th>RH</th><th>Setpoint</th><th>Mode</th>'
+        '</tr></thead>'
+        f'<tbody>{"".join(rows)}</tbody>'
+        '</table></div>'
+    )
+
+
+@section('shopping')
+def render_shopping_list(ha):
+    items = ha.todo_items(SHOPPING_LIST, status='needs_action')
+    if not items:
+        return ''
+    bullets = ''.join(f'<li>{i.get("summary", "")}</li>' for i in items)
+    return (
+        '<div style="margin: 0 0 10px 0;">'
+        '<h3 style="margin: 0 0 4px 0;">Shopping list</h3>'
+        f'<ul style="margin: 0; padding-left: 20px;">{bullets}</ul>'
+        '</div>'
+    )
+
 
 def main():
     load_dotenv()
-
-    # HA Config
-    ha_url = os.getenv("HA_URL", "http://192.168.68.104:8123")
-    ha_token = os.getenv("HA_TOKEN")
-    
-    # Gemini Config
-    gemini_key = os.getenv("GEMINI_API_KEY")
+    ha_url = os.getenv('HA_URL', 'http://192.168.68.104:8123')
+    ha_token = os.getenv('HA_TOKEN')
+    tz_name = os.getenv('TZ', 'America/Halifax')
 
     if not ha_token:
-        print("<div id='ha-update'><p>Error: HA_TOKEN not set.</p></div>")
+        print(
+            f'<div id="ha-daily-update" style="{WRAPPER_STYLE}">'
+            '<h2>Home Status</h2>'
+            '<p>HA_TOKEN not set; skipping home status.</p>'
+            '</div>'
+        )
         return
 
-    # 1. Fetch HA Data
-    states = get_ha_state(ha_url, ha_token)
-    filtered_states = filter_states(states)
-    ha_context = json.dumps(filtered_states, indent=2)
-    
-    # 1b. Fetch History for Graph
-    # Using Living Room and Office as they were found in discovery
-    graph_entities = ["sensor.living_room_thermostat_temperature", "sensor.office_thermostat_temperature"]
-    history_data = get_history(ha_url, ha_token, graph_entities)
-    svg_chart = create_line_chart(history_data)
+    try:
+        tz = ZoneInfo(tz_name)
+    except Exception:
+        tz = ZoneInfo('America/Halifax')
 
-    # 2. Generate Content with Gemini
-    if gemini_key:
-        client = genai.Client(api_key=gemini_key)
-        today = date.today().strftime("%B %d, %Y")
-        
-        prompt = f"""It is {today}.
-        
-I am providing you with the JSON state of my Smart Home (Home Assistant). 
-Please analyze it and write a short, engaging "Daily Home Status" briefing.
+    ha = HA(ha_url, ha_token)
 
-Key things to look for and summarize:
-- Weather forecast (if available).
-- Climate status (indoor temps, thermostat settings).
-- Any doors/windows left open?
-- High energy usage?
-- Battery levels of devices (warn if any are low).
-- Upcoming calendar events (trash pickup?).
-- Anything else unusual or interesting.
+    sections = [
+        render_header(ha, tz),
+        render_weather_now(ha, tz),
+        render_hourly_forecast(ha, tz),
+        render_anomalies(ha),
+        render_today_calendar(ha, tz),
+        render_climate_table(ha),
+        render_shopping_list(ha),
+    ]
 
-Keep it concise, bulleted, and friendly. Do not use emojis or icons (Kindle does not render them). Use plain text symbols if needed (like * or -).
+    body = '\n'.join(s for s in sections if s)
+    if not body:
+        body = '<p>(No home data available right now.)</p>'
 
-HOME DATA:
-{ha_context}
-"""
-        try:
-            response = client.models.generate_content(
-                model='gemini-2.0-flash-001',
-                contents=prompt
-            )
-            formatted_text = response.text.replace('\n', '<br>')
-        except Exception as e:
-            formatted_text = f"Error generating summary: {e}"
-    else:
-        formatted_text = "GEMINI_API_KEY not set. Cannot generate summary."
+    print(f'<div id="ha-daily-update" style="{WRAPPER_STYLE}">\n{body}\n</div>')
 
-    # 3. Output HTML
-    html_content = f"""
-    <div id="ha-daily-update" style="font-family: sans-serif; padding: 10px; border: 1px solid #ccc; border-radius: 5px;">
-        <h2>Home Status</h2>
-        <p>{formatted_text}</p>
-        {svg_chart}
-    </div>
-    """
 
-    print(html_content)
-
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()


### PR DESCRIPTION
## Summary
  - Replaces the Gemini-driven Home Status summary (was hitting 429 quota every morning by serialising ~300 HA entities into the
  prompt) and the half-broken 24h temperature SVG (hardcoded entity IDs, partial-data scaling) with deterministic sections      
  rendered from HA REST: header (date + sunset / next sunrise), current weather, 12h forecast strip (temp polyline +             
  precipitation-chance bars), heads-up anomalies (water leaks, doors/windows open, batteries ≤ 20%, unlocked locks), today's
  calendar with Halifax waste pickup highlighted and other `calendar.*` entities auto-discovered, indoor climate table over every
   `climate.*`, and the shopping list `todo`.                                                                                    
  - Each section is wrapped so a single endpoint failure logs to stderr and renders empty rather than taking the whole briefing
  down.                                                                                                                        
  - `docker-compose.yml` switches to `network_mode: host` (needed for the LAN HA URL) and drops two unwired Gmail-auth file      
  mounts. Adds a `CLAUDE.md` capturing the project layout for future Claude Code sessions.                                 
                                                                                                                                 
  ## Test plan                                              
  - [ ] `docker compose up -d --force-recreate` — startup cycle runs, PDF lands at `./downloads/cbc-news-YYYY-MM-DD.pdf`.        
  - [ ] Home Status section in the PDF shows: header line with sunset/sunrise, weather one-liner with high/low, 12h forecast
  strip, today's calendar (waste pickup line first when relevant), indoor climate table, shopping list.                          
  - [ ] Heads-up section renders only when something's actually wrong (toggle by temporarily opening a door sensor or simulating 
  a low battery).                                                                                                                
  - [ ] Force a section failure (e.g. set `HA_URL=http://127.0.0.1:1` briefly) → the broken section disappears and a single      
  `[ha-section:…]` line appears in `docker compose logs`; rest of the PDF still renders.                                   
  - [ ] Telegram delivery still fires when configured (was previously bypassing `--disable-send` by design).                     
  